### PR TITLE
tools: Starlink coastal-coverage layer for ForeFlight (and SkyDemon)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,11 @@ SQLAlchemy==2.0.44
 uvicorn==0.38.0
 euro-aip>=0.14.0
 flyfun-common>=0.1.2
+# KML/geometry for the ForeFlight export tools (tools/foreflight.py, tools/starlink.py)
+simplekml==1.3.2
+shapely==2.1.2
+pyproj==3.7.2
+pyshp==3.1.6
 chromadb==1.3.5
 requests==2.32.4
 authlib==1.6.0

--- a/tools/README.md
+++ b/tools/README.md
@@ -28,6 +28,8 @@ source dev.env
 | `aipchange.py` | Compare two AIP sources (e.g., sequential AIRAC cycles) and report field-level deltas. |
 | `bordercrossingexport.py` | Build a model enriched with customs/border crossing data and export it to database/JSON for downstream use. |
 | `foreflight.py` | Create ForeFlight content packs (KML/CSV + manifest) from the Euro AIP database or custom Excel definitions. |
+| `starlink.py` | Build a ForeFlight map layer showing where Starlink coastal coverage ends (the 12 NM offshore limit). |
+| `ffpack.py` | Shared helper, not a CLI: content pack directory + `manifest.json` handling, used by `foreflight.py` and `starlink.py`. |
 
 ## `aipexport.py`
 
@@ -132,6 +134,49 @@ python foreflight.py CustomApproach -c approach -x ./approach_definition.xlsx -n
   - `simplekml` for KML generation (already listed in `requirements.txt`)
 - **Outputs**
   - Content pack directory containing `manifest.json`, `navdata/*.kml`, and optional updated Excel (`*_updated.xlsx`)
+
+## `starlink.py`
+
+- **Use when** you want to see in the cockpit where Starlink stops working. Starlink's land/Roam
+  service reaches territorial waters only out to 12 NM from the coast; this draws that limit as a
+  ForeFlight map layer.
+- **Example (the default covers UK + France + Spain + Balearics)**
+
+```bash
+source dev.env
+python starlink.py Starlink12NM -r western-europe -n
+```
+
+- **Key options**
+  - `-r/--region`: `western-europe` (default), `uk-ireland`, `mediterranean`, `atlantic-islands`,
+    `scandinavia`, `europe`. Or `--bbox W,S,E,N` for anything else.
+  - `--distance-nm`: the rule itself, default 12. Change it and the layer follows.
+  - `--source`: coastline dataset, default `gshhg-h` (~200 m). Also `gshhg-i`, `ne10m`, `osm`.
+  - `--no-fill`: emit only the limit line, skipping the shaded beyond-limit layer.
+  - `--kmz FILE`: also write a single-file KMZ with both layers as folders, for checking the
+    result in Google Earth before loading it on the iPad. The content pack `.zip` is *not* a KMZ
+    (a KMZ needs `doc.kml` at the archive root), so use this rather than renaming the pack.
+  - `--out-dir DIR`: build the pack somewhere other than the current directory, e.g. `out/`.
+- **Outputs**
+  - `layers/<Name>Limit.kml` — the offshore limit, as one placemark holding a MultiGeometry of
+    LineStrings. Islands and enclosed water (mid Irish Sea) come out as their own closed rings.
+  - `layers/<Name>Beyond.kml` — translucent wash over the water past the limit. Separate file so
+    ForeFlight lists it as an independent toggle.
+- **Notes**
+  - Every run measures its own output: it resamples the emitted limit and reports the geodesic
+    distance back to land. Expect a median near 12.0 NM and ~100% of samples within 0.5 NM. This
+    checks the buffer maths, *not* the fidelity of the source coastline.
+  - The limit is buffered from the *physical* shoreline, so it is conservative. Legal territorial
+    seas use straight baselines that close bays, which sit further out in places like Norway and
+    the French Biscay coast.
+  - **Resolution is a memory decision, not a quality preference.** Detail below a few hundred
+    metres cannot survive a 22 km buffer, and peak memory in GEOS scales with the number of
+    polygon parts fed to one buffer call. Full-resolution OSM coastline is 5.3M vertices for the
+    British Isles alone; buffering an archipelago in one call has been measured at 30 GB. Hence
+    the defaults simplify on read and buffer in small batches, and `--max-vertices` /
+    `--memory-limit-mb` exist to abort rather than let the machine swap.
+- **Dependencies**
+  - `shapely`, `pyproj`, `pyshp`, `simplekml`
 
 ---
 

--- a/tools/ffpack.py
+++ b/tools/ffpack.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+"""
+ForeFlight content pack scaffolding, shared by the tools that emit packs.
+
+A content pack is a directory (ForeFlight also accepts it zipped) holding an
+optional ``manifest.json`` plus up to three well-known subdirectories:
+
+  layers/   georeferenced charts (mbtiles) and KML map layers
+  navdata/  user waypoint CSVs and the PDFs they link to
+  byop/     "bring your own plates" PDFs
+
+Every KML file in ``layers/`` becomes its own independently toggleable entry in
+ForeFlight's map layer list — which is why a tool that wants "boundary line"
+and "shaded area" as separate switches ships them as two files rather than two
+placemarks in one file.
+
+Manifest fields are all optional as far as ForeFlight is concerned; the version
+is what the app uses to notice that a reinstalled pack is newer, so the usual
+workflow is to keep the number monotonic via ``adopt_version(next_version=True)``.
+"""
+
+import datetime
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ContentPack:
+    """A ForeFlight content pack directory being created or refreshed."""
+
+    LAYERS = 'layers'
+    NAVDATA = 'navdata'
+    BYOP = 'byop'
+
+    def __init__(
+        self,
+        path,
+        name: str,
+        abbreviation: str,
+        organization: str = 'flyfun.aero',
+        version: int = 1,
+    ):
+        """
+        Args:
+            path: Directory for the pack (created if missing)
+            name: Human readable pack name shown in ForeFlight
+            abbreviation: Short tag ForeFlight shows against pack content
+            organization: Publisher name
+            version: Version to use when the pack does not exist yet
+        """
+        self.path = Path(path)
+        self.name = name
+        self.abbreviation = abbreviation
+        self.organization = organization
+        self.version = version
+        self.path.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def manifest_path(self) -> Path:
+        return self.path / 'manifest.json'
+
+    def subdir(self, which: str) -> Path:
+        """Return one of the well-known subdirectories, creating it on demand."""
+        if which not in (self.LAYERS, self.NAVDATA, self.BYOP):
+            raise ValueError(f'Not a ForeFlight content pack subdirectory: {which}')
+        directory = self.path / which
+        directory.mkdir(exist_ok=True)
+        return directory
+
+    def existing_version(self) -> Optional[int]:
+        """Version recorded in an already-present manifest, if any."""
+        if not self.manifest_path.exists():
+            return None
+        with open(self.manifest_path, 'r') as f:
+            return json.load(f).get('version')
+
+    def adopt_version(self, next_version: bool = False) -> bool:
+        """
+        Take the version from an existing manifest, optionally incrementing it.
+
+        Returns True when the version was incremented, so callers that encode
+        the version into the abbreviation can update it.
+        """
+        existing = self.existing_version()
+        if existing is None:
+            return False
+        self.version = existing
+        if not next_version:
+            return False
+        self.version += 1
+        logger.info(f'Incrementing version to {self.version}')
+        return True
+
+    def write_manifest(self, expiration_days: int = 365) -> dict:
+        """Write manifest.json, dated from now, and return what was written."""
+        now = datetime.datetime.now()
+        manifest = {
+            'name': self.name,
+            'abbreviation': self.abbreviation,
+            'version': self.version,
+            'organizationName': self.organization,
+            'effectiveDate': now.isoformat(),
+            'expirationDate': (now + datetime.timedelta(days=int(expiration_days))).isoformat(),
+        }
+        with open(self.manifest_path, 'w') as f:
+            json.dump(manifest, f, indent=2)
+        logger.info(f'Writing {self.manifest_path}')
+        return manifest

--- a/tools/foreflight.py
+++ b/tools/foreflight.py
@@ -76,8 +76,6 @@ from pathlib import Path
 from typing import List, Optional, Dict, Any
 from pprint import pprint
 import simplekml
-import json
-import datetime
 import pandas as pd
 import os
 try:
@@ -88,6 +86,8 @@ except ImportError:
 from euro_aip.storage.database_storage import DatabaseStorage
 from euro_aip.models.euro_aip_model import EuroAipModel
 from euro_aip.models.navpoint import NavPoint
+
+from ffpack import ContentPack
 
 # Configure logging
 logging.basicConfig(
@@ -273,39 +273,16 @@ class Command:
 
     def build_database_content_pack(self):
         """Build a complete ForeFlight content pack from database."""
-        name = self.args.name
-        pack_dir = Path(name)
-        pack_dir.mkdir(exist_ok=True)
-        
-        nav_dir = pack_dir / 'navdata'
-        nav_dir.mkdir(exist_ok=True)
-
-        # Create or update manifest
-        manifest_file = pack_dir / 'manifest.json'
-        manifest_data = {
-            'name': 'Point of Entry',
-            'abbreviation': 'POE.V2',
-            'version': 2,
-            'organizationName': 'flyfun.aero'
-        }
-
-        if manifest_file.exists():
-            with open(manifest_file, 'r') as f:
-                existing = json.load(f)
-            manifest_data['version'] = existing['version']
-            if self.args.next_version:
-                manifest_data['version'] += 1
-                logger.info(f'Incrementing version to {manifest_data["version"]}')
-
-        manifest_data['effectiveDate'] = datetime.datetime.now().isoformat()
-        days = int(self.args.expiration)
-        manifest_data['expirationDate'] = (
-            datetime.datetime.now() + datetime.timedelta(days=days)
-        ).isoformat()
-
-        with open(manifest_file, 'w') as f:
-            json.dump(manifest_data, f, indent=2)
-        logger.info(f'Writing {manifest_file}')
+        pack = ContentPack(
+            self.args.name,
+            name='Point of Entry',
+            abbreviation='POE.V2',
+            version=2,
+        )
+        # The abbreviation is intentionally not re-stamped with the version here.
+        pack.adopt_version(self.args.next_version)
+        pack.write_manifest(self.args.expiration)
+        nav_dir = pack.subdir(ContentPack.NAVDATA)
 
         # Build KML files
         self.build_approaches(str(nav_dir / 'Approaches.kml'))
@@ -317,41 +294,17 @@ class Command:
         
         # Open and process the Excel file
         self.open_definition_file(name)
-        
-        # Create content pack directory
-        pack_dir = Path(name)
-        pack_dir.mkdir(exist_ok=True)
-        
-        nav_dir = pack_dir / 'navdata'
-        nav_dir.mkdir(exist_ok=True)
 
-        # Create or update manifest
-        manifest_file = pack_dir / 'manifest.json'
-        manifest_data = {
-            'name': 'Custom Approaches',
-            'abbreviation': f'{name}.V1',
-            'version': 1,
-            'organizationName': 'flyfun.aero'
-        }
-
-        if manifest_file.exists():
-            with open(manifest_file, 'r') as f:
-                existing = json.load(f)
-            manifest_data['version'] = existing['version']
-            if self.args.next_version:
-                manifest_data['version'] += 1
-                manifest_data['abbreviation'] = f'{name}.V{manifest_data["version"]}'
-                logger.info(f'Incrementing version to {manifest_data["version"]}')
-
-        manifest_data['effectiveDate'] = datetime.datetime.now().isoformat()
-        days = int(self.args.expiration)
-        manifest_data['expirationDate'] = (
-            datetime.datetime.now() + datetime.timedelta(days=days)
-        ).isoformat()
-
-        with open(manifest_file, 'w') as f:
-            json.dump(manifest_data, f, indent=2)
-        logger.info(f'Writing {manifest_file}')
+        pack = ContentPack(
+            name,
+            name='Custom Approaches',
+            abbreviation=f'{name}.V1',
+            version=1,
+        )
+        if pack.adopt_version(self.args.next_version):
+            pack.abbreviation = f'{name}.V{pack.version}'
+        pack.write_manifest(self.args.expiration)
+        nav_dir = pack.subdir(ContentPack.NAVDATA)
 
         # Process waypoints and write navdata
         self.process_waypoints()

--- a/tools/starlink.py
+++ b/tools/starlink.py
@@ -1,0 +1,1087 @@
+#!/usr/bin/env python3
+
+"""
+Starlink coastal-coverage limit as a ForeFlight map layer.
+
+Why
+---
+Starlink's land/Roam service reaches territorial waters out to 12 NM from the
+coast; past that the link drops unless the aircraft is on a maritime/aviation
+plan. (Roam additionally caps coastal water at 5 consecutive / 60 annual days.)
+For flight planning the useful question is simply "where does the link stop?",
+so this tool draws that one line.
+
+What it builds
+--------------
+  layers/<Name>Limit.kml    the offshore limit as LineStrings. Islands and
+                            enclosed water — mid Irish Sea, mid Adriatic — fall
+                            out naturally as their own closed rings.
+  layers/<Name>Beyond.kml   optional translucent wash over the water beyond the
+                            limit, as a separate toggle.
+
+Both go in layers/, so ForeFlight lists them as two independent map layers and
+the wash can be switched off without losing the line.
+
+Emitting the limit as lines rather than a filled polygon is deliberate: a line
+does not hide the weather and airspace underneath it, and nothing depends on
+how ForeFlight handles polygon fill or ring winding order.
+
+Choosing a coastline resolution — read this before switching --source
+--------------------------------------------------------------------
+The buffer distance sets how much coastline detail can possibly matter. At
+12 NM (22.2 km) any wiggle below a few hundred metres is erased by the buffer
+itself, so a generalized coastline gives the same answer as a full-resolution
+one for far less work. This is not a minor tuning knob: the full-resolution OSM
+land polygons carry 5.3 million vertices for the British Isles alone, and
+GEOS union/buffer over that allocates tens of GB. Hence the defaults here are
+a generalized source plus simplification applied as each polygon is read, so
+full-resolution geometry never accumulates in memory.
+
+Two guards keep a bad combination from taking the machine down rather than just
+failing: --max-vertices refuses to start the expensive stage on an oversized
+input, and --memory-limit-mb runs a watchdog that aborts the process if its own
+memory use runs away. The watchdog polls RSS rather than calling setrlimit
+because macOS refuses to lower RLIMIT_AS/DATA/RSS, so an address-space cap here
+would silently do nothing.
+
+How the geometry is built
+-------------------------
+1. Land polygons are read for the region, clipped and simplified on the way in.
+2. Land is binned into a coarse grid and each cell is buffered by the coverage
+   distance in an azimuthal-equidistant projection centred on that cell.
+   Minkowski dilation distributes over union — buffer(A u B) == buffer(A) u
+   buffer(B) — so buffering per cell and then unioning is exact rather than an
+   approximation, while keeping every buffer within the few hundred km where
+   AEQD stays metrically faithful. A single projection spanning Europe and the
+   Atlantic islands would not.
+3. The boundary of that union is the coverage limit.
+4. A verification pass resamples the emitted boundary and measures the true
+   geodesic distance from each sample back to the land it came from. Note this
+   validates the buffer and projection maths, not the fidelity of the source
+   coastline — a 1 km-generalized source verifies clean while still sitting
+   ~1 km off the real shore.
+
+This buffers the *physical* shoreline, which is deliberately conservative.
+Starlink describes the limit in terms of territorial waters, and legal
+territorial seas are drawn from straight baselines that close bays and
+skerries, so off Norway or the French Biscay coast the legal 12 NM limit lies
+further out than 12 NM from the shoreline. Where this layer says "dark" you may
+still have signal; where it says "covered" you should have it.
+
+Usage:
+  python tools/starlink.py [NAME]
+      [-r REGION | --bbox W,S,E,N]
+      [--distance-nm NM] [--source SOURCE]
+      [--land-simplify-m M] [--simplify-m M]
+      [--no-fill] [--out-dir DIR] [--kmz FILE] [--geojson FILE]
+      [--next-version] [--expiration DAYS]
+      [--cache-dir DIR] [--max-vertices N] [--memory-limit-mb MB]
+      [--verify-report] [--skip-verify] [-v|--verbose]
+
+Examples:
+  # Default: UK + France + Spain + Balearics, 12 NM
+  python tools/starlink.py
+
+  # Just the British Isles, line only, bumped version
+  python tools/starlink.py Starlink12NM -r uk-ireland --no-fill -n
+
+  # A different rule (e.g. a plan with a wider coastal allowance)
+  python tools/starlink.py Starlink20NM --distance-nm 20
+
+  # Everything from the Azores to the Black Sea (slow, big file)
+  python tools/starlink.py Starlink12NM -r europe
+
+  # Build into out/ and also emit a KMZ to eyeball in Google Earth first
+  python tools/starlink.py Starlink12NM --out-dir out --kmz out/preview.kmz
+
+  # Custom area, and dump GeoJSON to inspect in QGIS/geojson.io
+  python tools/starlink.py --bbox -15,45,10,60 --geojson /tmp/limit.geojson
+"""
+
+import argparse
+import json
+import logging
+import math
+import os
+import sys
+import threading
+import time
+import zipfile
+from collections import defaultdict
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+from urllib.request import urlopen
+
+import pyproj
+import shapefile  # pyshp
+import shapely
+import simplekml
+from shapely.errors import GEOSException
+from shapely.geometry import Point, box, mapping, shape
+from shapely.geometry.base import BaseGeometry
+from shapely.ops import transform, unary_union
+from shapely.strtree import STRtree
+
+from ffpack import ContentPack
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+NM_IN_M = 1852.0
+M_PER_DEG_LAT = 111320.0
+
+REGIONS: Dict[str, Tuple[float, float, float, float]] = {
+    'europe':           (-32.0, 26.0, 45.0, 72.0),
+    # Far enough south for the Balearics (Mallorca is at 39.6 N) so a
+    # UK -> France -> Spain -> Mallorca trip fits in one layer.
+    'western-europe':   (-13.0, 35.0, 20.0, 62.0),
+    'uk-ireland':       (-13.0, 47.0,  4.0, 62.0),
+    'mediterranean':    ( -7.0, 29.0, 37.0, 47.0),
+    'atlantic-islands': (-32.0, 26.0, -12.0, 41.0),
+    'scandinavia':      ( -2.0, 53.0, 33.0, 72.0),
+}
+
+# Land beyond the region still shapes the limit inside it, so read a margin far
+# wider than any sane coverage distance.
+REGION_MARGIN_DEG = 3.0
+
+# Cell size for per-cell buffering. 5 degrees keeps every point within roughly
+# 300 km of its projection centre, where AEQD tangential scale error is well
+# under 0.1% — a few metres on a 22 km buffer.
+CELL_DEG = 5.0
+
+# How many polygons to hand to a single buffer call. Peak memory in GEOS scales
+# with the number of parts noded together, not with vertex count, so this is the
+# knob that keeps archipelagos affordable. See _dilate.
+BUFFER_BATCH = 64
+
+# Watchdog poll interval. Deliberately short: the archipelago failure mode grew
+# from 133 MB to 30 GB inside two seconds, so a lazy poll never sees it coming.
+WATCHDOG_INTERVAL_S = 0.25
+
+
+# ---------------------------------------------------------------------------
+# guards
+# ---------------------------------------------------------------------------
+
+def peak_rss_mb() -> float:
+    """Peak resident set size of this process, in MB."""
+    import resource
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # ru_maxrss is bytes on macOS/BSD, kilobytes on Linux.
+    return peak / (1024 * 1024) if sys.platform == 'darwin' else peak / 1024
+
+
+def start_memory_watchdog(megabytes: int) -> None:
+    """
+    Abort the process if its own memory use runs away.
+
+    setrlimit is not an option here: macOS refuses to lower RLIMIT_AS, DATA or
+    RSS, so a runaway buffer operation would take the whole machine into swap
+    before Python ever saw a MemoryError. Watching our own peak RSS and bailing
+    out is crude but it is enforced, and dying is much cheaper than wedging the
+    user's laptop. --max-vertices is the guard that normally prevents ever
+    getting here; this is the backstop for when an estimate is wrong.
+    """
+    if not megabytes or megabytes <= 0:
+        logger.warning('Memory watchdog disabled — a detailed --source can exhaust the machine')
+        return
+
+    def watch():
+        while True:
+            used = peak_rss_mb()
+            if used > megabytes:
+                logger.error(
+                    'Aborting: memory use %.0f MB exceeded --memory-limit-mb %d. '
+                    'Raise --land-simplify-m, pick a coarser --source, or shrink the region.'
+                    % (used, megabytes)
+                )
+                os._exit(2)
+            time.sleep(WATCHDOG_INTERVAL_S)
+
+    threading.Thread(target=watch, daemon=True, name='memory-watchdog').start()
+    logger.debug(f'Memory watchdog armed at {megabytes} MB')
+
+
+# ---------------------------------------------------------------------------
+# projection helpers
+# ---------------------------------------------------------------------------
+
+@lru_cache(maxsize=512)
+def _aeqd(lat0: float, lon0: float):
+    """Forward/inverse transforms for an AEQD frame centred on (lat0, lon0)."""
+    crs = pyproj.CRS.from_proj4(
+        f'+proj=aeqd +lat_0={lat0} +lon_0={lon0} +datum=WGS84 +units=m +no_defs'
+    )
+    fwd = pyproj.Transformer.from_crs('EPSG:4326', crs, always_xy=True).transform
+    inv = pyproj.Transformer.from_crs(crs, 'EPSG:4326', always_xy=True).transform
+    return fwd, inv
+
+
+GEOD = pyproj.Geod(ellps='WGS84')
+
+
+def _cell_of(lon: float, lat: float, cell_deg: float = CELL_DEG) -> Tuple[int, int]:
+    return (math.floor(lon / cell_deg), math.floor(lat / cell_deg))
+
+
+def _cell_centre(cell: Tuple[int, int], cell_deg: float = CELL_DEG) -> Tuple[float, float]:
+    ix, iy = cell
+    return ((ix + 0.5) * cell_deg, (iy + 0.5) * cell_deg)
+
+
+def _parts(geom: Optional[BaseGeometry], types: Sequence[str]) -> List[BaseGeometry]:
+    """Flatten a geometry down to the requested primitive types."""
+    if geom is None or geom.is_empty:
+        return []
+    if geom.geom_type in types:
+        return [geom]
+    if hasattr(geom, 'geoms'):
+        out: List[BaseGeometry] = []
+        for g in geom.geoms:
+            out.extend(_parts(g, types))
+        return out
+    return []
+
+
+def polygons_of(geom: Optional[BaseGeometry]) -> List[BaseGeometry]:
+    return _parts(geom, ('Polygon',))
+
+
+def lines_of(geom: Optional[BaseGeometry]) -> List[BaseGeometry]:
+    return _parts(geom, ('LineString', 'LinearRing'))
+
+
+def count_vertices(geom) -> int:
+    if isinstance(geom, (list, tuple)):
+        return int(sum(shapely.get_num_coordinates(g) for g in geom))
+    return int(shapely.get_num_coordinates(geom))
+
+
+# ---------------------------------------------------------------------------
+# coastline sources
+# ---------------------------------------------------------------------------
+
+class CoastlineSource:
+    """
+    A cached coastline dataset, read back as land polygons for a bounding box.
+
+    Subclasses stream features and hand each one to _accept, which clips and
+    simplifies immediately — the point being that full-resolution geometry is
+    never held in memory all at once.
+    """
+
+    #: Nominal positional accuracy, for logging so the choice is visible.
+    accuracy_note = ''
+
+    def __init__(self, cache_dir):
+        self.cache_dir = Path(cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _fetch(self, url: str, filename: Optional[str] = None) -> Path:
+        dest = self.cache_dir / (filename or os.path.basename(url))
+        if dest.exists() and dest.stat().st_size > 0:
+            logger.debug(f'Using cached {dest}')
+            return dest
+        logger.info(f'Downloading {url}')
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with urlopen(url) as response, open(dest, 'wb') as out:
+            while True:
+                chunk = response.read(1 << 20)
+                if not chunk:
+                    break
+                out.write(chunk)
+        logger.info(f'Cached {dest} ({dest.stat().st_size / 1e6:.1f} MB)')
+        return dest
+
+    def _unzip(self, archive: Path) -> Path:
+        target = self.cache_dir / archive.stem
+        if not target.exists():
+            logger.info(f'Extracting {archive}')
+            with zipfile.ZipFile(archive) as zf:
+                zf.extractall(target)
+        return target
+
+    @staticmethod
+    def _accept(geom: BaseGeometry, clip, simplify_deg: float, out: List[BaseGeometry]) -> None:
+        """Clip, simplify and stash a single feature, discarding the original."""
+        if not geom.is_valid:
+            geom = geom.buffer(0)
+        geom = geom.intersection(clip)
+        if geom.is_empty:
+            return
+        if simplify_deg > 0:
+            # preserve_topology keeps small islands from collapsing to nothing —
+            # they are the whole reason for using a multipart source.
+            geom = geom.simplify(simplify_deg, preserve_topology=True)
+            if geom.is_empty:
+                return
+            # Simplification is per-feature, so it can leave a ring crossing
+            # itself or a neighbour. Repair here or the union downstream throws
+            # "side location conflict".
+            if not geom.is_valid:
+                geom = shapely.make_valid(geom)
+        out.extend(polygons_of(geom))
+
+    def polygons(self, bbox, simplify_deg: float) -> List[BaseGeometry]:
+        raise NotImplementedError
+
+
+class GshhgSource(CoastlineSource):
+    """
+    GSHHG shorelines (Wessel & Smith) — the standard hierarchical coastline.
+
+    Level 1 is the land/ocean boundary. Resolutions run c/l/i/h/f from crude to
+    full; 'h' is roughly 200 m and is ample under a 12 NM buffer.
+    """
+
+    URL = 'https://www.soest.hawaii.edu/pwessel/gshhg/gshhg-shp-2.3.7.zip'
+    ACCURACY = {'c': '~25 km', 'l': '~5 km', 'i': '~1 km', 'h': '~200 m', 'f': 'full'}
+
+    def __init__(self, cache_dir, resolution: str = 'h'):
+        super().__init__(cache_dir)
+        self.resolution = resolution
+        self.accuracy_note = f'GSHHG-{resolution} ({self.ACCURACY.get(resolution, "?")})'
+
+    def shapefile_path(self) -> Path:
+        root = self._unzip(self._fetch(self.URL))
+        wanted = f'GSHHS_{self.resolution}_L1.shp'
+        for candidate in root.glob(f'**/{wanted}'):
+            return candidate
+        raise ValueError(f'{wanted} not found under {root}')
+
+    def polygons(self, bbox, simplify_deg: float) -> List[BaseGeometry]:
+        west, south, east, north = bbox
+        clip = box(west, south, east, north)
+        shp = self.shapefile_path()
+        logger.info(f'Reading {shp.name} for bbox {bbox}')
+
+        kept: List[BaseGeometry] = []
+        with shapefile.Reader(str(shp)) as reader:
+            for record in reader.iterShapes(bbox=(west, south, east, north)):
+                if record is None:
+                    continue
+                self._accept(shape(record.__geo_interface__), clip, simplify_deg, kept)
+        return kept
+
+
+class NaturalEarthSource(CoastlineSource):
+    """
+    Natural Earth 1:10m land plus minor islands.
+
+    Coarser than GSHHG-h (roughly 1 km) but tiny and dependency-free, and the
+    minor-islands file has to be loaded alongside the main one or the Channel
+    Islands and similar disappear.
+    """
+
+    BASE = 'https://raw.githubusercontent.com/nvkelso/natural-earth-vector/master/geojson/'
+    FILES = ('ne_10m_land.geojson', 'ne_10m_minor_islands.geojson')
+    accuracy_note = 'Natural Earth 10m (~1 km)'
+
+    def polygons(self, bbox, simplify_deg: float) -> List[BaseGeometry]:
+        west, south, east, north = bbox
+        clip = box(west, south, east, north)
+        kept: List[BaseGeometry] = []
+        for filename in self.FILES:
+            path = self._fetch(self.BASE + filename, f'naturalearth/{filename}')
+            logger.info(f'Reading {filename} for bbox {bbox}')
+            with open(path) as f:
+                collection = json.load(f)
+            for feature in collection['features']:
+                geom = shape(feature['geometry'])
+                if not geom.intersects(clip):
+                    continue
+                self._accept(geom, clip, simplify_deg, kept)
+            del collection
+        return kept
+
+
+class OsmSource(CoastlineSource):
+    """
+    OSM land polygons — full resolution, best fidelity, and heavy.
+
+    870k features globally and 5.3M vertices for the British Isles alone, so
+    simplification on read is not optional here. Kept available because it is
+    the only source that is current to the week.
+    """
+
+    URL = 'https://osmdata.openstreetmap.de/download/land-polygons-split-4326.zip'
+    accuracy_note = 'OSM land polygons (full resolution)'
+
+    def shapefile_path(self) -> Path:
+        root = self._unzip(self._fetch(self.URL))
+        for candidate in sorted(root.glob('**/*.shp')):
+            return candidate
+        raise ValueError(f'No .shp found under {root}')
+
+    def polygons(self, bbox, simplify_deg: float) -> List[BaseGeometry]:
+        west, south, east, north = bbox
+        clip = box(west, south, east, north)
+        shp = self.shapefile_path()
+        logger.info(f'Reading {shp.name} for bbox {bbox} (full-resolution source)')
+        if simplify_deg <= 0:
+            logger.warning(
+                'Reading OSM land polygons without simplification — this can need '
+                'tens of GB downstream. Use --land-simplify-m 300 or more.'
+            )
+
+        kept: List[BaseGeometry] = []
+        with shapefile.Reader(str(shp)) as reader:
+            # pyshp's bbox filter reads each record's stored bounding box and
+            # seeks past the rest, so the features outside the region are cheap.
+            for record in reader.iterShapes(bbox=(west, south, east, north)):
+                if record is None:
+                    continue
+                self._accept(shape(record.__geo_interface__), clip, simplify_deg, kept)
+        return kept
+
+
+SOURCES = {
+    'gshhg-i': lambda cache: GshhgSource(cache, 'i'),
+    'gshhg-h': lambda cache: GshhgSource(cache, 'h'),
+    'gshhg-f': lambda cache: GshhgSource(cache, 'f'),
+    'ne10m':   NaturalEarthSource,
+    'osm':     OsmSource,
+}
+
+
+# ---------------------------------------------------------------------------
+# geometry
+# ---------------------------------------------------------------------------
+
+def _safe_union(geoms: Sequence[BaseGeometry]) -> BaseGeometry:
+    """Union, repairing inputs and retrying if GEOS rejects them."""
+    try:
+        return unary_union(geoms)
+    except GEOSException as exc:
+        logger.debug(f'union failed ({exc}); repairing inputs and retrying')
+        return unary_union([shapely.make_valid(g) for g in geoms])
+
+
+def _dilate(
+    members: Sequence[BaseGeometry],
+    distance_m: float,
+    quad_segs: int,
+    batch_size: int = BUFFER_BATCH,
+) -> BaseGeometry:
+    """
+    Dilate a group of projected polygons, in batches.
+
+    The trap this avoids: calling buffer() once on a MultiPolygon with thousands
+    of parts. GEOS generates the offset curves for every part and nodes them in
+    a single pass, so the Åland/Turku archipelago — 6,905 islands but only 35k
+    vertices — needs 30 GB and two minutes to yield a 525-vertex result. Peak
+    memory there is driven by the number of parts handed to one buffer call, not
+    by the vertex count, which is why an innocuous-looking input explodes.
+
+    Buffering small batches and unioning progressively keeps every intermediate
+    small. The result is identical because dilation distributes over union, and
+    overlapping buffers collapse into few components as they accumulate.
+    """
+    accumulated: Optional[BaseGeometry] = None
+    for start in range(0, len(members), batch_size):
+        chunk = list(members[start:start + batch_size])
+        try:
+            grown = unary_union(chunk).buffer(distance_m, quad_segs=quad_segs)
+        except GEOSException as exc:
+            # A union of independently simplified coastline can trip GEOS
+            # robustness ("side location conflict"); buffering each member is
+            # slower but far more forgiving.
+            logger.debug(f'union-before-buffer failed ({exc}); buffering members individually')
+            grown = _safe_union([m.buffer(distance_m, quad_segs=quad_segs) for m in chunk])
+        accumulated = grown if accumulated is None else _safe_union([accumulated, grown])
+    return accumulated
+
+
+def grid_land(
+    land: Sequence[BaseGeometry],
+    bbox,
+    cell_deg: float = CELL_DEG,
+) -> Dict[Tuple[int, int], List[BaseGeometry]]:
+    """
+    Clip land into grid cells so every piece lies inside the cell that holds it.
+
+    Binning whole polygons by centroid is not good enough: one polygon can be a
+    whole continent, which would then be projected in a frame centred thousands
+    of km from most of it, and would be invisible to any lookup that only
+    consults neighbouring cells. Cutting the land on the grid keeps both the
+    projection and the nearest-land search honestly local.
+
+    The cuts are safe. They add edges along cell borders, but those edges are
+    interior to the union of all the pieces, so the buffer union absorbs them —
+    the same reason buffering per cell and unioning is exact.
+    """
+    west, south, east, north = bbox
+    tree = STRtree(list(land))
+    cells: Dict[Tuple[int, int], List[BaseGeometry]] = {}
+    for ix in range(math.floor(west / cell_deg), math.floor(east / cell_deg) + 1):
+        for iy in range(math.floor(south / cell_deg), math.floor(north / cell_deg) + 1):
+            cell_box = box(ix * cell_deg, iy * cell_deg,
+                           (ix + 1) * cell_deg, (iy + 1) * cell_deg)
+            pieces: List[BaseGeometry] = []
+            for index in tree.query(cell_box):
+                clipped = land[index].intersection(cell_box)
+                if not clipped.is_empty:
+                    pieces.extend(polygons_of(clipped))
+            if pieces:
+                cells[(ix, iy)] = pieces
+    logger.info(
+        'Gridded %d land polygons into %d cells (%d pieces)'
+        % (len(land), len(cells), sum(len(v) for v in cells.values()))
+    )
+    return cells
+
+
+def buffer_land(
+    cells: Dict[Tuple[int, int], List[BaseGeometry]],
+    distance_nm: float,
+    cell_deg: float = CELL_DEG,
+    quad_segs: int = 8,
+) -> BaseGeometry:
+    """
+    Dilate land by distance_nm, cell by cell in local equidistant frames.
+
+    Exact rather than approximate: dilation distributes over union, so the union
+    of per-cell buffers is the buffer of the union. Each cell is projected to
+    its own AEQD frame so no part of the buffer is measured far from its
+    projection centre.
+    """
+    total = sum(len(v) for v in cells.values())
+    logger.info(f'Buffering {total} land pieces by {distance_nm} NM across {len(cells)} cells')
+    distance_m = distance_nm * NM_IN_M
+    buffered: List[BaseGeometry] = []
+    for cell, members in sorted(cells.items()):
+        lon0, lat0 = _cell_centre(cell, cell_deg)
+        fwd, inv = _aeqd(lat0, lon0)
+        projected = [transform(fwd, poly) for poly in members]
+        grown = _dilate(projected, distance_m, quad_segs)
+        del projected
+        buffered.append(transform(inv, grown))
+        logger.debug(f'  cell {cell}: {len(members)} polygons -> {count_vertices(buffered[-1])} vertices')
+
+    logger.info('Merging buffered cells')
+    union = _safe_union(buffered)
+    if not union.is_valid:
+        union = shapely.make_valid(union)
+    return union
+
+
+def simplify_geographic(geom: BaseGeometry, tolerance_m: float) -> BaseGeometry:
+    """
+    Simplify with a tolerance in metres, part by part in local frames.
+
+    Applied after the union so the artificial edges where source tiles were cut
+    are already gone and cannot be simplified into visible kinks.
+    """
+    if tolerance_m <= 0:
+        return geom
+    simplified: List[BaseGeometry] = []
+    for part in polygons_of(geom):
+        centre = part.representative_point()
+        fwd, inv = _aeqd(centre.y, centre.x)
+        reduced = transform(fwd, part).simplify(tolerance_m)
+        if reduced.is_empty:
+            continue
+        if not reduced.is_valid:
+            reduced = shapely.make_valid(reduced)
+        simplified.append(transform(inv, reduced))
+    out = _safe_union(simplified)
+    return out if out.is_valid else shapely.make_valid(out)
+
+
+def limit_lines(coverage: BaseGeometry, region) -> List[BaseGeometry]:
+    """Coverage boundary, trimmed to the region so the read margin is not drawn."""
+    west, south, east, north = region
+    clipped = coverage.boundary.intersection(box(west, south, east, north))
+    lines = [line for line in lines_of(clipped) if line.length > 0]
+    logger.info(f'Coverage limit: {len(lines)} line strings, {count_vertices(lines)} vertices')
+    return lines
+
+
+def beyond_limit(coverage: BaseGeometry, region) -> List[BaseGeometry]:
+    """Water outside the coverage limit, inside the region."""
+    west, south, east, north = region
+    return polygons_of(box(west, south, east, north).difference(coverage))
+
+
+# ---------------------------------------------------------------------------
+# verification
+# ---------------------------------------------------------------------------
+
+def verify_limit(
+    lines: Sequence[BaseGeometry],
+    land_cells: Dict[Tuple[int, int], List[BaseGeometry]],
+    distance_nm: float,
+    cell_deg: float = CELL_DEG,
+) -> dict:
+    """
+    Measure the true geodesic distance from the emitted limit back to land.
+
+    Samples every vertex plus each segment midpoint — vertices catch systematic
+    offset error, midpoints catch corners cut inward by simplification. Work is
+    binned by cell so each measurement happens in a local metric frame, and the
+    reported number is a geodesic distance on the ellipsoid.
+    """
+    sample_cells: Dict[Tuple[int, int], List[Tuple[float, float]]] = defaultdict(list)
+    for line in lines:
+        coords = list(line.coords)
+        for (x1, y1), (x2, y2) in zip(coords, coords[1:]):
+            sample_cells[_cell_of(x1, y1, cell_deg)].append((x1, y1))
+            mx, my = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+            sample_cells[_cell_of(mx, my, cell_deg)].append((mx, my))
+        if coords:
+            x, y = coords[-1]
+            sample_cells[_cell_of(x, y, cell_deg)].append((x, y))
+
+    distances: List[float] = []
+    unmeasured = 0
+    for cell, samples in sorted(sample_cells.items()):
+        ix, iy = cell
+        nearby: List[BaseGeometry] = []
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                nearby.extend(land_cells.get((ix + dx, iy + dy), []))
+        if not nearby:
+            unmeasured += len(samples)
+            continue
+
+        lon0, lat0 = _cell_centre(cell, cell_deg)
+        fwd, inv = _aeqd(lat0, lon0)
+        projected = [transform(fwd, poly) for poly in nearby]
+        tree = STRtree(projected)
+
+        for lon, lat in samples:
+            point = transform(fwd, Point(lon, lat))
+            nearest = projected[tree.nearest(point)]
+            ring = nearest.exterior
+            back = transform(inv, ring.interpolate(ring.project(point)))
+            _, _, metres = GEOD.inv(lon, lat, back.x, back.y)
+            distances.append(metres / NM_IN_M)
+
+    if not distances:
+        return {'samples': 0, 'unmeasured': unmeasured}
+
+    distances.sort()
+    n = len(distances)
+    within = sum(1 for d in distances if abs(d - distance_nm) <= 0.5)
+    return {
+        'samples': n,
+        'unmeasured': unmeasured,
+        'target_nm': distance_nm,
+        'min': distances[0],
+        'p05': distances[int(0.05 * n)],
+        'median': distances[n // 2],
+        'p95': distances[int(0.95 * n)],
+        'max': distances[-1],
+        'within_half_nm_pct': 100.0 * within / n,
+    }
+
+
+def log_verification(stats: dict) -> None:
+    if not stats.get('samples'):
+        logger.warning('Verification produced no measurable samples')
+        return
+    logger.info(
+        'Limit vs land (target %.1f NM): min %.2f  p05 %.2f  median %.2f  p95 %.2f  max %.2f NM'
+        % (stats['target_nm'], stats['min'], stats['p05'], stats['median'],
+           stats['p95'], stats['max'])
+    )
+    logger.info(
+        'Within 0.5 NM of target: %.1f%% of %d samples'
+        % (stats['within_half_nm_pct'], stats['samples'])
+    )
+    if stats['within_half_nm_pct'] < 95.0:
+        logger.warning('Less than 95%% of the limit sits within 0.5 NM of target — inspect the output')
+
+
+# ---------------------------------------------------------------------------
+# KML output
+# ---------------------------------------------------------------------------
+
+def write_limit_kml(dest: Path, lines, distance_nm: float, colour: str) -> None:
+    """
+    One placemark holding a MultiGeometry of every boundary line.
+
+    Collapsing thousands of rings into a single placemark keeps one inline style
+    for the whole layer instead of one per ring, which matters for both file
+    size and how quickly ForeFlight draws it.
+    """
+    kml = simplekml.Kml(name=f'Starlink {distance_nm:g} NM limit')
+    multi = kml.newmultigeometry(name=f'Starlink {distance_nm:g} NM coverage limit')
+    multi.description = (
+        f'Seaward limit of Starlink land/Roam coverage, {distance_nm:g} NM from the '
+        'shoreline. Beyond this line the link drops without a maritime or aviation '
+        'plan. Buffered from the physical coast, so it is conservative where '
+        'territorial sea baselines close a bay.'
+    )
+    for line in lines:
+        multi.newlinestring(coords=list(line.coords))
+    multi.style.linestyle.color = colour
+    multi.style.linestyle.width = 2
+
+    logger.info(f'Writing {dest}')
+    kml.save(str(dest))
+
+
+def write_beyond_kml(dest: Path, water, distance_nm: float, colour: str) -> None:
+    """Translucent wash over the water beyond the limit, outline suppressed."""
+    kml = simplekml.Kml(name=f'Beyond Starlink {distance_nm:g} NM')
+    multi = kml.newmultigeometry(name=f'No Starlink coverage (beyond {distance_nm:g} NM)')
+    multi.description = (
+        f'Water more than {distance_nm:g} NM from the shoreline — outside Starlink '
+        'land/Roam coverage.'
+    )
+    for poly in water:
+        multi.newpolygon(
+            outerboundaryis=list(poly.exterior.coords),
+            innerboundaryis=[list(ring.coords) for ring in poly.interiors],
+        )
+    multi.style.polystyle.color = colour
+    multi.style.polystyle.outline = 0
+    multi.style.linestyle.width = 0
+
+    logger.info(f'Writing {dest}')
+    kml.save(str(dest))
+
+
+def write_preview_kmz(dest: Path, lines, water, distance_nm: float,
+                      line_colour: str, fill_colour: str) -> None:
+    """
+    Both layers in one KMZ, as separate folders, for desktop preview.
+
+    ForeFlight wants the layers as separate files in the pack; Google Earth is
+    happier with a single file, and its web importer only takes one. A KMZ needs
+    doc.kml at the archive root, so the content pack zip cannot be reused for
+    this — it holds manifest.json and layers/ instead.
+    """
+    kml = simplekml.Kml(name=f'Starlink {distance_nm:g} NM preview')
+
+    limit_folder = kml.newfolder(name=f'{distance_nm:g} NM coverage limit')
+    multi = limit_folder.newmultigeometry(name='Coverage limit')
+    for line in lines:
+        multi.newlinestring(coords=list(line.coords))
+    multi.style.linestyle.color = line_colour
+    multi.style.linestyle.width = 2
+
+    if water:
+        water_folder = kml.newfolder(name=f'No coverage (beyond {distance_nm:g} NM)')
+        wash = water_folder.newmultigeometry(name='Beyond limit')
+        for poly in water:
+            wash.newpolygon(
+                outerboundaryis=list(poly.exterior.coords),
+                innerboundaryis=[list(ring.coords) for ring in poly.interiors],
+            )
+        wash.style.polystyle.color = fill_colour
+        wash.style.polystyle.outline = 0
+        wash.style.linestyle.width = 0
+
+    logger.info(f'Writing {dest}')
+    kml.savekmz(str(dest))
+
+
+def _dms(value: float, hemispheres: str, degree_width: int) -> str:
+    """Format a coordinate as SkyDemon's packed DMS, e.g. N583553.97 / W0023842.28."""
+    hemisphere = hemispheres[0] if value >= 0 else hemispheres[1]
+    remainder = abs(value)
+    degrees = int(remainder)
+    remainder = (remainder - degrees) * 60.0
+    minutes = int(remainder)
+    seconds = round((remainder - minutes) * 60.0, 2)
+    # Rounding can carry: 59.999 s becomes 60.00 and must roll up.
+    if seconds >= 60.0:
+        seconds -= 60.0
+        minutes += 1
+    if minutes >= 60:
+        minutes -= 60
+        degrees += 1
+    return f'{hemisphere}{degrees:0{degree_width}d}{minutes:02d}{seconds:05.2f}'
+
+
+def _skydemon_block(title: str, ring) -> List[str]:
+    """One airspace definition. Header repeated per block so each is self-contained."""
+    lines = ['#', 'TYPE=OTHER', 'SUBTYPE=Starlink', '#', '#',
+             f'TITLE={title}', 'REF=STARLINK', 'BASE=MSL', 'TOPS=UNL']
+    coords = list(ring.coords)
+    # Close the ring explicitly. His Europe file did not, leaving SkyDemon to
+    # join the Barents coast to the Black Sea with a 1,516 NM straight line.
+    if coords[0] != coords[-1]:
+        coords.append(coords[0])
+    for lon, lat in coords:
+        lines.append(f'POINT={_dms(lat, "NS", 2)} {_dms(lon, "EW", 3)}')
+    return lines
+
+
+def _ring_area_nm2(ring) -> float:
+    """Geodesic area enclosed by a ring, in square nautical miles."""
+    area_m2, _ = GEOD.geometry_area_perimeter(ring)
+    return abs(area_m2) / (NM_IN_M ** 2)
+
+
+def _coord_label(point) -> str:
+    return (f'{abs(point.y):.1f}{"N" if point.y >= 0 else "S"} '
+            f'{abs(point.x):06.2f}{"E" if point.x >= 0 else "W"}')
+
+
+def write_skydemon(dest: Path, polygons: Sequence[BaseGeometry], distance_nm: float,
+                   split: bool = False, min_gap_nm2: float = 25.0) -> None:
+    """
+    Write the same boundary in SkyDemon's custom-airspace format.
+
+    The format holds one closed ring per block, with no holes and no multipart
+    geometry — which is what cost the original files every offshore island. The
+    workaround is one ring per block: each landmass group gets its own, and each
+    enclosed gap gets one labelled GAP so it is not mistaken for coverage.
+
+    The format is not publicly documented, so the layout mirrors the observed
+    files byte for byte, CRLF endings included. Evidence suggests SkyDemon takes
+    one airspace per file (the source files were split that way), so split=True
+    writes one file per ring — drop them all in SkyDemon's CustomData folder.
+
+    Gaps below min_gap_nm2 are dropped: a hole a couple of NM across is noise
+    under a 12 NM rule and would just add clutter. The count is logged, never
+    silently discarded.
+    """
+    ordered = sorted(polygons, key=lambda g: -g.area)
+    blocks: List[Tuple[str, List[str]]] = []
+    area_no = gap_no = 0
+    dropped = 0
+    for poly in ordered:
+        area_no += 1
+        title = (f'STARLINK {distance_nm:g}NM AREA {area_no:02d} '
+                 f'{_coord_label(poly.representative_point())}')
+        blocks.append((f'area{area_no:02d}', _skydemon_block(title, poly.exterior)))
+        for ring in poly.interiors:
+            if _ring_area_nm2(ring) < min_gap_nm2:
+                dropped += 1
+                continue
+            gap_no += 1
+            gap_title = (f'STARLINK {distance_nm:g}NM GAP {gap_no:02d} '
+                         f'{_coord_label(ring.centroid)}')
+            blocks.append((f'gap{gap_no:02d}', _skydemon_block(gap_title, ring)))
+    if dropped:
+        logger.info(f'Dropped {dropped} enclosed gaps smaller than {min_gap_nm2:g} NM2')
+
+    # newline='' plus explicit \r\n keeps the CRLF endings the observed files use.
+    with open(dest, 'w', newline='') as f:
+        for _, block in blocks:
+            f.write('\r\n'.join(block) + '\r\n')
+    points = sum(len(b) for _, b in blocks)
+    logger.info(
+        f'Writing {dest}: {len(blocks)} blocks ({area_no} areas, {gap_no} gaps), ~{points} lines'
+    )
+
+    if split:
+        for name, block in blocks:
+            part = dest.with_name(f'{dest.stem}_{name}{dest.suffix}')
+            with open(part, 'w', newline='') as f:
+                f.write('\r\n'.join(block) + '\r\n')
+        logger.info(f'Also wrote {len(blocks)} single-block files next to {dest.name}')
+
+
+def write_geojson(dest: Path, lines) -> None:
+    collection = {
+        'type': 'FeatureCollection',
+        'features': [
+            {'type': 'Feature', 'properties': {}, 'geometry': mapping(line)}
+            for line in lines
+        ],
+    }
+    logger.info(f'Writing {dest}')
+    with open(dest, 'w') as f:
+        json.dump(collection, f)
+
+
+# ---------------------------------------------------------------------------
+# command
+# ---------------------------------------------------------------------------
+
+class Command:
+    """Command-line interface for the Starlink coverage layer."""
+
+    def __init__(self, args):
+        self.args = args
+        self.region = self._resolve_region()
+
+    def _resolve_region(self):
+        if self.args.bbox:
+            parts = [float(v) for v in self.args.bbox.split(',')]
+            if len(parts) != 4:
+                raise ValueError('--bbox needs four comma-separated values: W,S,E,N')
+            west, south, east, north = parts
+            if west >= east or south >= north:
+                raise ValueError(f'--bbox is not a valid box: {self.args.bbox}')
+            return (west, south, east, north)
+        return REGIONS[self.args.region]
+
+    def load_land(self) -> List[BaseGeometry]:
+        west, south, east, north = self.region
+        margin = REGION_MARGIN_DEG
+        read_bbox = (west - margin, south - margin, east + margin, north + margin)
+
+        source = SOURCES[self.args.source](self.args.cache_dir)
+        # Simplify in degrees on the way in. Using the latitude scale for both
+        # axes under-simplifies in longitude away from the equator, which errs
+        # towards keeping detail rather than losing it.
+        simplify_deg = self.args.land_simplify_m / M_PER_DEG_LAT
+        logger.info(
+            'Coastline source: %s, simplified on read at %.0f m'
+            % (source.accuracy_note or self.args.source, self.args.land_simplify_m)
+        )
+        land = source.polygons(read_bbox, simplify_deg)
+        if not land:
+            raise ValueError(f'No land found in {read_bbox} — check the region')
+
+        vertices = count_vertices(land)
+        logger.info(f'Land: {len(land)} polygons, {vertices} vertices')
+        if vertices > self.args.max_vertices:
+            raise ValueError(
+                f'Land geometry has {vertices} vertices, above --max-vertices '
+                f'({self.args.max_vertices}). Buffering this much detail can need '
+                f'tens of GB and is pointless under a {self.args.distance_nm:g} NM '
+                f'buffer. Raise --land-simplify-m, choose a coarser --source, or '
+                f'shrink the region.'
+            )
+        return land
+
+    def run(self):
+        start_memory_watchdog(self.args.memory_limit_mb)
+
+        west, south, east, north = self.region
+        logger.info(
+            'Region %s: %.1f..%.1f E, %.1f..%.1f N'
+            % (self.args.bbox or self.args.region, west, east, south, north)
+        )
+
+        land = self.load_land()
+        margin = REGION_MARGIN_DEG
+        cells = grid_land(land, (west - margin, south - margin, east + margin, north + margin))
+        del land
+
+        coverage = buffer_land(cells, self.args.distance_nm)
+        if self.args.simplify_m > 0:
+            before = count_vertices(coverage)
+            coverage = simplify_geographic(coverage, self.args.simplify_m)
+            logger.info(
+                'Simplified output at %.0f m: %d -> %d vertices'
+                % (self.args.simplify_m, before, count_vertices(coverage))
+            )
+
+        lines = limit_lines(coverage, self.region)
+
+        if not self.args.skip_verify:
+            stats = verify_limit(lines, cells, self.args.distance_nm)
+            log_verification(stats)
+            if self.args.verify_report:
+                for key, value in stats.items():
+                    logger.info(f'  {key}: {value}')
+
+        name = self.args.name
+        pack = ContentPack(
+            Path(self.args.out_dir) / name,
+            name=f'Starlink {self.args.distance_nm:g} NM',
+            abbreviation=f'{name}.V1',
+            version=1,
+        )
+        if pack.adopt_version(self.args.next_version):
+            pack.abbreviation = f'{name}.V{pack.version}'
+        pack.write_manifest(self.args.expiration)
+        layers = pack.subdir(ContentPack.LAYERS)
+
+        write_limit_kml(layers / f'{name}Limit.kml', lines, self.args.distance_nm,
+                        self.args.line_color)
+        water = [] if self.args.no_fill else beyond_limit(coverage, self.region)
+        if not self.args.no_fill:
+            write_beyond_kml(layers / f'{name}Beyond.kml', water,
+                             self.args.distance_nm, self.args.fill_color)
+
+        if self.args.skydemon:
+            # Deliberately NOT clipped to the region. An airspace must be a closed
+            # ring, so wherever the data stops the ring closes with a straight leg
+            # along the cut. Clipping to the region puts those legs right through
+            # the area of interest — a ~1000 NM straight line across the Med,
+            # indistinguishable from the artefact this export exists to avoid.
+            # Using the unclipped coverage pushes them out to the read margin
+            # instead, and keeps island groups near the region edge (the Faroes)
+            # whole. Inside the region the boundary is identical to the KML.
+            write_skydemon(Path(self.args.skydemon), polygons_of(coverage),
+                           self.args.distance_nm,
+                           split=self.args.skydemon_split,
+                           min_gap_nm2=self.args.min_gap_nm2)
+
+        if self.args.kmz:
+            write_preview_kmz(Path(self.args.kmz), lines, water, self.args.distance_nm,
+                              self.args.line_color, self.args.fill_color)
+
+        if self.args.geojson:
+            write_geojson(Path(self.args.geojson), lines)
+
+        logger.info(f'Content pack ready: {pack.path} (version {pack.version})')
+        logger.info('Install: AirDrop or copy the folder (or a zip of it) into ForeFlight')
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Build a ForeFlight content pack with the Starlink coastal coverage limit'
+    )
+    parser.add_argument('name', nargs='?', default='Starlink12NM',
+                        help='Name of the content pack (default: Starlink12NM)')
+    parser.add_argument('-r', '--region', choices=sorted(REGIONS), default='western-europe',
+                        help='Predefined area to cover (default: western-europe)')
+    parser.add_argument('--bbox', help='Explicit area as W,S,E,N in degrees (overrides --region)')
+    parser.add_argument('--distance-nm', type=float, default=12.0,
+                        help='Coverage distance from the coast in NM (default: 12)')
+    parser.add_argument('--source', choices=sorted(SOURCES), default='gshhg-h',
+                        help='Coastline dataset (default: gshhg-h, ~200 m)')
+    parser.add_argument('--land-simplify-m', type=float, default=300.0,
+                        help='Simplify land on read, in metres (default: 300). Detail below '
+                             'this cannot survive a 12 NM buffer anyway.')
+    parser.add_argument('--simplify-m', type=float, default=500.0,
+                        help='Simplify the output limit, in metres, 0 to disable (default: 500)')
+    parser.add_argument('--no-fill', action='store_true',
+                        help='Emit only the limit line, no shaded beyond-limit layer')
+    parser.add_argument('--line-color', default=simplekml.Color.magenta,
+                        help='KML aabbggrr colour for the limit line')
+    parser.add_argument('--fill-color', default='40ff00ff',
+                        help='KML aabbggrr colour for the beyond-limit wash')
+    parser.add_argument('--out-dir', default='.',
+                        help='Directory to build the pack in (default: current directory). '
+                             'The pack name stays clean, so use this rather than a path in NAME.')
+    parser.add_argument('--kmz', help='Also write a single-file KMZ (both layers as folders) '
+                                      'for previewing in Google Earth')
+    parser.add_argument('--skydemon', help='Also write the same boundary as a SkyDemon '
+                                           'custom-airspace file (.airspace)')
+    parser.add_argument('--skydemon-split', action='store_true',
+                        help='With --skydemon, also write one file per area/gap, since SkyDemon '
+                             'appears to take a single airspace per file')
+    parser.add_argument('--min-gap-nm2', type=float, default=25.0,
+                        help='Skip enclosed no-coverage gaps smaller than this, in square NM '
+                             '(default: 25)')
+    parser.add_argument('--geojson', help='Also write the limit lines to this GeoJSON file')
+    parser.add_argument('-n', '--next-version', action='store_true', help='Increment pack version')
+    parser.add_argument('-e', '--expiration', type=int, default=365, help='Expiration in days')
+    parser.add_argument('--cache-dir', default='cache/coastline',
+                        help='Where to cache coastline downloads (default: cache/coastline)')
+    parser.add_argument('--max-vertices', type=int, default=600_000,
+                        help='Refuse to buffer land with more vertices than this (default: 600000)')
+    parser.add_argument('--memory-limit-mb', type=int, default=6000,
+                        help='Abort if own memory use exceeds this many MB, 0 to disable '
+                             '(default: 6000)')
+    parser.add_argument('--verify-report', action='store_true',
+                        help='Log the full verification breakdown')
+    parser.add_argument('--skip-verify', action='store_true',
+                        help='Skip the geodesic check of the emitted limit')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
+
+    args = parser.parse_args()
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    Command(args).run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

`tools/starlink.py` draws the **Starlink coastal-coverage limit** as a ForeFlight map layer. Starlink's land/Roam service only reaches territorial waters out to 12 NM from the coast, so the useful question in the cockpit is "where does the link stop?" — this draws that line.

Outputs, all from one geometry pass:

| output | purpose |
|---|---|
| `layers/<Name>Limit.kml` | the offshore limit, MultiGeometry LineStrings |
| `layers/<Name>Beyond.kml` | translucent wash past the limit, separate ForeFlight toggle |
| `--kmz` | single-file KMZ for Google Earth preview |
| `--skydemon` | SkyDemon `.airspace`, one ring per file |
| `--geojson` | QGIS / geojson.io inspection |

Motivated by a real trip (UK → Cannes → Barcelona → Mallorca). The default region covers UK + France + Spain + Balearics. **Confirmed working on-device in ForeFlight.**

## Why lines rather than a filled polygon

A line doesn't hide the weather and airspace underneath it, you can't fill open ocean without inventing a clipping frame, and a line depends on none of ForeFlight's polygon-fill or ring-winding behaviour. Islands and enclosed water fall out naturally as their own closed rings.

## How the geometry works

Land is buffered **cell by cell** in a local azimuthal-equidistant frame, then unioned. This is exact, not an approximation: Minkowski dilation distributes over union, `buffer(A ∪ B) == buffer(A) ∪ buffer(B)`. That property is what lets each buffer stay inside the few hundred km where AEQD is metrically faithful — a single projection spanning Europe plus the Atlantic islands would not be.

Land is *clipped* to the grid rather than binned by centroid. Binning whole polygons by centroid puts a continent-sized polygon in one cell, which both projects most of it far from its frame centre and hides it from any neighbour-cell lookup.

## Verification

Every run measures its own output — resampling the emitted limit and computing the geodesic distance back to land:

```
Limit vs land (target 12.0 NM): min 11.69  p05 11.76  median 11.95  p95 12.00  max 12.22 NM
Within 0.5 NM of target: 100.0% of 7190 samples
```

The slight inward bias is output simplification cutting corners, which errs safe. This validates the buffer/projection maths, **not** the fidelity of the source coastline.

Also spot-checked by point-in-polygon: all of Isle of Man, Jersey, Guernsey, Shetland, Orkney, Stornoway, Scilly, Mallorca, Ibiza, Menorca, Corsica, Sardinia, Sicily, Malta, Gotland, Faroes read as covered; mid Irish Sea, mid Biscay, mid North Sea, Celtic Sea, mid Kattegat and the Barcelona–Palma midpoint read as not covered.

## Resolution is a memory decision, not a quality preference

Worth knowing before anyone "upgrades" `--source`. Detail below a few hundred metres cannot survive a 22 km buffer, so a generalized coastline gives the same answer for far less work. Full-resolution OSM land polygons are **5.3M vertices for the British Isles alone**.

More subtly, **GEOS buffer peak memory scales with the number of polygon parts noded in one call, not with vertex count.** The Åland archipelago — 6,905 islands but only 35k vertices — cost **30.4 GB and 112 s** in a single `buffer()` call, to produce a 525-vertex result. Batched at 64 parts: **215 MB and 1.9 s**, output identical to 0.000 m² symmetric difference (verified against a single-call baseline on four cells).

Two guards make a bad combination fail instead of taking the machine down:
- `--max-vertices` refuses oversized input before the expensive stage
- `--memory-limit-mb` runs an RSS watchdog, polling every 0.25 s

The watchdog polls RSS rather than calling `setrlimit` because **macOS silently refuses to lower `RLIMIT_AS`/`DATA`/`RSS`** — an address-space cap on darwin is a no-op that looks like a guard. The short poll interval matters: the archipelago case grew 133 MB → 30 GB inside two seconds.

## Refactor

`foreflight.py` had content-pack directory + `manifest.json` handling duplicated inline in two methods. Extracted to `tools/ffpack.py` and used from both. Manifest output is **unchanged**, including the existing quirks — airports mode bumps `version` without re-stamping `abbreviation` (matching the committed `tools/pack/manifest.json`, which is `version: 3` / `POE.V2`), while approach mode re-stamps `.V{n}` only on increment. Verified against both fresh and existing manifests.

`requirements.txt` gains `shapely`, `pyproj`, `pyshp` — and `simplekml`, which `foreflight.py` already imported but was never listed (the README claimed otherwise).

## Note for review

Existing packs put KML in `navdata/`; ForeFlight's current docs put KML map layers in `layers/`. The new tool uses `layers/`. I did **not** change `foreflight.py`'s `navdata/` placement since that pack works in production.

Open question I could not resolve: whether SkyDemon reads multiple airspace definitions from one file. The format isn't publicly documented, so `--skydemon-split` emits one file per ring as a fallback.

## Test plan

- [x] `python tools/starlink.py -r uk-ireland` → 100% of 2,148 samples within 0.5 NM
- [x] `python tools/starlink.py -r western-europe` → 100% of 7,190 samples within 0.5 NM
- [x] Batched vs single-call buffer equivalence: 0.000 m² over 4 cells
- [x] Memory watchdog aborts as intended when limit is set below need
- [x] KML/KMZ well-formedness and structure asserted via ElementTree
- [x] SkyDemon output round-tripped through an independent parser: all rings closed, 26/26 spot checks pass
- [x] `ContentPack` manifest semantics: 10/10 checks incl. version/abbreviation quirks
- [x] Both CLIs `--help` intact; loaded and verified on-device in ForeFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)
